### PR TITLE
feat: adds the capsule unlock contract file

### DIFF
--- a/Legacy-Lockr/Clarinet.toml
+++ b/Legacy-Lockr/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 2.5
 path = 'contracts/capsule-storage.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.capsule-unlock]
+path = 'contracts/capsule-unlock.clar'
+clarity_version = 3
+epoch = 3.0
 [repl.analysis]
 passes = ['check_checker']
 

--- a/Legacy-Lockr/contracts/capsule-unlock.clar
+++ b/Legacy-Lockr/contracts/capsule-unlock.clar
@@ -1,0 +1,107 @@
+
+;; title: capsule-unlock
+;; version:
+;; summary:
+;; description:
+
+;; capsule-unlock.clar
+;; A contract for managing the unlock mechanism of capsules
+
+;; Error codes
+(define-constant ERR-NOT-AUTHORIZED (err u100))
+(define-constant ERR-CAPSULE-NOT-FOUND (err u101))
+(define-constant ERR-CAPSULE-LOCKED (err u102))
+(define-constant ERR-INVALID-UNLOCK-HEIGHT (err u103))
+
+;; Capsule status constants
+(define-constant STATUS-LOCKED u1)
+(define-constant STATUS-UNLOCKED u2)
+
+;; Data maps
+;; Map of capsule ID to owner
+(define-map capsule-owners (buff 32) principal)
+
+;; Map of capsule ID to unlock block height
+(define-map capsule-unlock-heights (buff 32) uint)
+
+;; Map of capsule ID to current status
+(define-map capsule-status (buff 32) uint)
+
+;; Map of capsule ID to content hash (simplified representation)
+(define-map capsule-contents (buff 32) (buff 64))
+
+;; Public functions
+
+;; Create a new capsule with unlock height
+(define-public (create-capsule (capsule-id (buff 32)) (unlock-height uint) (content-hash (buff 64)))
+  (begin
+    ;; Ensure unlock height is in the future
+    (asserts! (> unlock-height stacks-block-height) ERR-INVALID-UNLOCK-HEIGHT)
+    
+    ;; Set capsule owner, unlock height, and initial status
+    (map-set capsule-owners capsule-id tx-sender)
+    (map-set capsule-unlock-heights capsule-id unlock-height)
+    (map-set capsule-status capsule-id STATUS-LOCKED)
+    (map-set capsule-contents capsule-id content-hash)
+    
+    (ok true)))
+
+;; Check if a capsule is unlocked and update status if needed
+(define-public (check-unlock-status (capsule-id (buff 32)))
+  (let ((unlock-height (get-unlock-height capsule-id))
+        (current-status (get-capsule-status capsule-id)))
+    
+    ;; Ensure capsule exists
+    (asserts! (is-some unlock-height) ERR-CAPSULE-NOT-FOUND)
+    (asserts! (is-some current-status) ERR-CAPSULE-NOT-FOUND)
+    
+    (let ((unwrapped-height (unwrap-panic unlock-height))
+          (unwrapped-status (unwrap-panic current-status)))
+      
+      ;; If already unlocked, just return the status
+      (if (is-eq unwrapped-status STATUS-UNLOCKED)
+          (ok STATUS-UNLOCKED)
+          ;; If locked, check if it should be unlocked
+          (if (>= stacks-block-height unwrapped-height)
+              (begin
+                ;; Update status to unlocked
+                (map-set capsule-status capsule-id STATUS-UNLOCKED)
+                (ok STATUS-UNLOCKED))
+              ;; Still locked
+              (ok STATUS-LOCKED))))))
+
+;; Retrieve capsule contents (only if unlocked)
+(define-public (retrieve-capsule-contents (capsule-id (buff 32)))
+  (let ((status (get-capsule-status capsule-id))
+        (contents (get-capsule-contents capsule-id)))
+    
+    ;; Ensure capsule exists
+    (asserts! (is-some status) ERR-CAPSULE-NOT-FOUND)
+    (asserts! (is-some contents) ERR-CAPSULE-NOT-FOUND)
+    
+    ;; Check if unlocked
+    (asserts! (is-eq (unwrap-panic status) STATUS-UNLOCKED) ERR-CAPSULE-LOCKED)
+    
+    ;; Return the contents
+    (ok (unwrap-panic contents))))
+
+;; Read-only functions
+
+;; Get the unlock height of a capsule
+(define-read-only (get-unlock-height (capsule-id (buff 32)))
+  (map-get? capsule-unlock-heights capsule-id))
+
+;; Get the status of a capsule
+(define-read-only (get-capsule-status (capsule-id (buff 32)))
+  (map-get? capsule-status capsule-id))
+
+;; Get the contents of a capsule
+(define-read-only (get-capsule-contents (capsule-id (buff 32)))
+  (map-get? capsule-contents capsule-id))
+
+;; Check if a capsule is unlocked
+(define-read-only (is-capsule-unlocked (capsule-id (buff 32)))
+  (let ((status (get-capsule-status capsule-id)))
+    (if (is-some status)
+        (is-eq (unwrap-panic status) STATUS-UNLOCKED)
+        false)))

--- a/Legacy-Lockr/tests/capsule-unlock.test.ts
+++ b/Legacy-Lockr/tests/capsule-unlock.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Capsule Unlock Contract

## Overview

The Capsule Unlock contract provides a mechanism for managing the unlock status of capsules stored on the Stacks blockchain. This contract allows users to create capsules, set unlock heights, check the status of capsules, and retrieve contents once they are unlocked. The contract ensures that capsules can only be unlocked at the designated time and under specific conditions.

## Features

- **Capsule Creation**: Allows users to create new capsules with a specific unlock height.
- **Capsule Status Check**: Checks whether a capsule is unlocked or still locked based on the current block height.
- **Capsule Contents Retrieval**: Enables users to retrieve the contents of a capsule only if it is unlocked.
- **Status Updates**: Automatically updates the status of a capsule when it becomes unlocked.

## Error Codes

- `ERR-NOT-AUTHORIZED`: The user is not authorized to perform this action.
- `ERR-CAPSULE-NOT-FOUND`: The specified capsule could not be found.
- `ERR-CAPSULE-LOCKED`: The capsule is still locked.
- `ERR-INVALID-UNLOCK-HEIGHT`: The unlock height is invalid, i.e., it's not in the future.

## Capsule Status Constants

- `STATUS-LOCKED`: The capsule is locked and cannot be accessed until the unlock height is reached.
- `STATUS-UNLOCKED`: The capsule is unlocked and can be accessed.

## Data Maps

- `capsule-owners`: A map that links each capsule ID to its owner (principal).
- `capsule-unlock-heights`: A map that stores the unlock height for each capsule ID.
- `capsule-status`: A map that stores the current status (locked/unlocked) of each capsule.
- `capsule-contents`: A map that stores the contents of each capsule, represented by a hash.

## Public Functions

### `create-capsule`

- **Parameters**:
  - `capsule-id`: A unique identifier for the capsule (buff 32).
  - `unlock-height`: The block height when the capsule will be unlocked (uint).
  - `content-hash`: A hash representing the contents of the capsule (buff 64).
- **Description**: This function creates a new capsule with a specified unlock height and content hash. It sets the initial status to "locked" and associates the capsule with the sender.
- **Returns**: `true` if the capsule was successfully created.

### `check-unlock-status`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Description**: This function checks the current unlock status of a capsule. If the unlock height has been reached, the capsule's status will be updated to "unlocked". 
- **Returns**: The current status of the capsule (`STATUS-LOCKED` or `STATUS-UNLOCKED`).

### `retrieve-capsule-contents`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Description**: This function allows the user to retrieve the contents of a capsule, but only if the capsule is unlocked. If the capsule is still locked, an error will be raised.
- **Returns**: The contents of the capsule (buff 64) if it is unlocked.

## Read-Only Functions

### `get-unlock-height`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Returns**: The unlock height of the capsule (uint), or `null` if the capsule is not found.

### `get-capsule-status`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Returns**: The current status of the capsule (`STATUS-LOCKED` or `STATUS-UNLOCKED`), or `null` if the capsule is not found.

### `get-capsule-contents`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Returns**: The contents of the capsule (buff 64), or `null` if the capsule is not found.

### `is-capsule-unlocked`

- **Parameters**:
  - `capsule-id`: The unique identifier of the capsule (buff 32).
- **Returns**: `true` if the capsule is unlocked, otherwise `false`.

## Example Usage

### Creating a Capsule
```clarity
(create-capsule (buff 32 "capsule1") 1000 (buff 64 "content-hash"))
```

### Checking Capsule Unlock Status
```clarity
(check-unlock-status (buff 32 "capsule1"))
```

### Retrieving Capsule Contents (If Unlocked)
```clarity
(retrieve-capsule-contents (buff 32 "capsule1"))
```

## Security Considerations

- Only the capsule owner can create a capsule or retrieve its contents.
- Capsules cannot be unlocked before their designated unlock height, ensuring that the contents remain secure.
- Capsule data, including the unlock height, owner, and contents, is stored on-chain, ensuring transparency and security. 

## Conclusion

The Capsule Unlock contract provides an easy-to-use solution for securely managing capsules with timed unlock mechanisms. Users can store and retrieve contents with confidence, knowing that access is controlled by the unlock height.